### PR TITLE
fix(pr): correct variable name in PR creation process

### DIFF
--- a/src/github/prManager.js
+++ b/src/github/prManager.js
@@ -544,10 +544,10 @@ async function createOrUpdatePR(octokit, context, newVersion, commits, config, u
       }
     }
     
-    if (!branchUsed) {
+    if (!sourceUsed) {
       console.log(`Couldn't find changelog in any branch, will start fresh 💁‍♀️`);
     } else {
-      console.log(`Using changelog content from ${branchUsed} as base to avoid conflicts 💅`);
+      console.log(`Using changelog content from ${sourceUsed} as base to avoid conflicts 💅`);
     }
     
     // Generate changelog content using our new function


### PR DESCRIPTION
This PR fixes the CI/CD pipeline error where 'branchUsed' was undefined in the PR creation process.

## What's Changed 💁‍♀️
- Changed references from 'branchUsed' to 'sourceUsed' which is the variable that's actually being set in the code
- This fixes the error in the Release workflow that was preventing PRs from being created

## Testing 🧪
- The fix is simple and isolated to a single file
- This should resolve the CI/CD pipeline error seen in run 14922657127

Fixes the error: 'branchUsed is not defined'